### PR TITLE
fix: strict compliance with API and webhook security spec

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,12 +2,14 @@ PATH
   remote: .
   specs:
     abacatepay-ruby (0.2.0)
+      base64 (~> 0.2)
       faraday (~> 2.9)
 
 GEM
   remote: https://rubygems.org/
   specs:
     ast (2.4.3)
+    base64 (0.3.0)
     diff-lcs (1.6.2)
     docile (1.4.1)
     faraday (2.14.1)

--- a/abacatepay-ruby.gemspec
+++ b/abacatepay-ruby.gemspec
@@ -33,6 +33,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   # Runtime dependencies
+  spec.add_dependency "base64", "~> 0.2"
   spec.add_dependency "faraday", "~> 2.9"
 
   # Development dependencies

--- a/lib/abacate_pay/clients/client.rb
+++ b/lib/abacate_pay/clients/client.rb
@@ -37,6 +37,11 @@ module AbacatePay
         parsed.fetch("data")
       rescue Faraday::Error => e
         handle_request_error(e)
+      rescue AbacatePay::Error
+        # API-level errors (e.g. ApiError raised above) already carry the real
+        # cause — let them propagate untouched instead of being re-wrapped as
+        # "Unexpected error", which hides the original message.
+        raise
       rescue StandardError => e
         raise ApiError, "Unexpected error: #{e.message}"
       end

--- a/lib/abacate_pay/clients/customer_client.rb
+++ b/lib/abacate_pay/clients/customer_client.rb
@@ -40,7 +40,7 @@ module AbacatePay
           email: data.metadata&.email,
           cellphone: data.metadata&.cellphone,
           taxId: data.metadata&.tax_id
-        })
+        }.compact)
 
         Resources::Customers.new(response)
       end

--- a/lib/abacate_pay/clients/product_client.rb
+++ b/lib/abacate_pay/clients/product_client.rb
@@ -36,7 +36,7 @@ module AbacatePay
         request_data[:imageUrl] = data.image_url if data.image_url && !data.image_url.to_s.empty?
         request_data[:cycle] = data.cycle if data.cycle && !data.cycle.to_s.empty?
 
-        response = request("POST", "create", json: request_data)
+        response = request("POST", "create", json: request_data.compact)
         Resources::Products.new(response)
       end
 

--- a/lib/abacate_pay/configuration.rb
+++ b/lib/abacate_pay/configuration.rb
@@ -41,13 +41,14 @@ module AbacatePay
     end
 
     # Gets the base API URL, auto-detecting API version from token prefix.
-    # Tokens starting with "abc_dev_" or "abc_live_" are v2; others default to v1.
+    # Tokens starting with "abc_dev_", "abc_live_" or "abc_prod_" are v2;
+    # others (legacy keys) default to v1.
     #
     # @return [String] The base API URL
     #
     # @api public
     def api_url
-      version = api_token&.match?(/\Aabc_(dev|live)_/) ? "v2" : "v1"
+      version = api_token&.match?(/\Aabc_(dev|live|prod)_/) ? "v2" : "v1"
       "https://api.abacatepay.com/#{version}"
     end
   end

--- a/lib/abacate_pay/webhooks.rb
+++ b/lib/abacate_pay/webhooks.rb
@@ -1,22 +1,33 @@
 # frozen_string_literal: true
 
 require "openssl"
+require "base64"
 require "json"
 
 module AbacatePay
   module Webhooks
     class SignatureError < AbacatePay::Error; end
 
-    # Verifies a webhook signature using HMAC-SHA256.
+    # Fixed AbacatePay HMAC public key, used to sign all webhook deliveries.
+    # Per https://docs.abacatepay.com/pages/webhooks/security this is a
+    # global, non-secret value — it protects body integrity but does NOT
+    # authenticate origin (use the `webhookSecret` query parameter for that).
+    PUBLIC_KEY = "t9dXRhHHo3yDEj5pVDYz0frf7q6bMKyMRmxxCPIPp3RCplBfXRxqlC6ZpiWmOqj4L63qEaeUOtrCI8P0VMUgo6iIga2ri9ogaHFs0WIIywSMg0q7RmBfybe1E5XJcfC4IW3alNqym0tXoAKkzvfEjZxV6bE0oG2zJrNNYmUCKZyV0KZ3JS8Votf9EAWWYdiDkMkpbMdPggfh1EqHlVkMiTady6jOR3hyzGEHrIz2Ret0xHKMbiqkr9HS1JhNHDX9"
+
+    # Verifies a webhook signature using HMAC-SHA256 (base64-encoded).
+    #
+    # The signature is computed over the raw body using AbacatePay's fixed
+    # public key (PUBLIC_KEY constant). Callers can override the key for
+    # tests or future schemes.
     #
     # @param payload [String] The raw request body
     # @param signature [String] The X-Webhook-Signature header value
-    # @param secret [String] Your webhook secret/public key
+    # @param secret [String] Key used for HMAC. Defaults to PUBLIC_KEY.
     # @return [true] if signature is valid
     # @raise [SignatureError] if signature is invalid
-    def self.verify!(payload:, signature:, secret:)
-      expected = OpenSSL::HMAC.hexdigest("SHA256", secret, payload)
-      unless secure_compare(expected, signature)
+    def self.verify!(payload:, signature:, secret: PUBLIC_KEY)
+      expected = Base64.strict_encode64(OpenSSL::HMAC.digest("SHA256", secret, payload))
+      unless secure_compare(expected, signature.to_s)
         raise SignatureError, "Invalid webhook signature"
       end
       true
@@ -26,9 +37,9 @@ module AbacatePay
     #
     # @param payload [String] The raw request body
     # @param signature [String] The X-Webhook-Signature header value
-    # @param secret [String] Your webhook secret/public key
+    # @param secret [String] Key used for HMAC. Defaults to PUBLIC_KEY.
     # @return [Boolean]
-    def self.valid?(payload:, signature:, secret:)
+    def self.valid?(payload:, signature:, secret: PUBLIC_KEY)
       verify!(payload: payload, signature: signature, secret: secret)
       true
     rescue SignatureError

--- a/spec/clients/client_spec.rb
+++ b/spec/clients/client_spec.rb
@@ -71,6 +71,11 @@ RSpec.describe AbacatePay::Clients::Client do
         expect { client.call_request("GET", "bad") }
           .to raise_error(AbacatePay::ApiError)
       end
+
+      it "preserves the API error message without double-wrapping it" do
+        expect { client.call_request("GET", "bad") }
+          .to raise_error(AbacatePay::ApiError, "API error: something")
+      end
     end
 
     context "when a Faraday connection error occurs" do

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+RSpec.describe AbacatePay::Configuration do
+  subject(:config) { described_class.new }
+
+  describe "#api_url" do
+    context "with a v2 token prefix" do
+      %w[abc_dev_ abc_live_ abc_prod_].each do |prefix|
+        it "routes #{prefix}* tokens to v2" do
+          config.api_token = "#{prefix}secret123"
+          expect(config.api_url).to eq("https://api.abacatepay.com/v2")
+        end
+      end
+    end
+
+    context "with a non-v2 token" do
+      it "falls back to v1 for legacy tokens" do
+        config.api_token = "legacy_token_123"
+        expect(config.api_url).to eq("https://api.abacatepay.com/v1")
+      end
+
+      it "falls back to v1 when the token is nil" do
+        config.api_token = nil
+        expect(config.api_url).to eq("https://api.abacatepay.com/v1")
+      end
+    end
+  end
+end

--- a/spec/webhooks/webhook_spec.rb
+++ b/spec/webhooks/webhook_spec.rb
@@ -1,11 +1,12 @@
 # frozen_string_literal: true
 
 require "openssl"
+require "base64"
 
 RSpec.describe AbacatePay::Webhooks do
   let(:secret) { "test_webhook_secret_123" }
   let(:payload) { '{"event":"checkout.completed","data":{"id":"chk-1"}}' }
-  let(:valid_signature) { OpenSSL::HMAC.hexdigest("SHA256", secret, payload) }
+  let(:valid_signature) { Base64.strict_encode64(OpenSSL::HMAC.digest("SHA256", secret, payload)) }
 
   describe ".verify!" do
     it "returns true for a valid signature" do
@@ -39,6 +40,15 @@ RSpec.describe AbacatePay::Webhooks do
       expect(
         described_class.valid?(payload: payload, signature: "bad", secret: secret)
       ).to be false
+    end
+  end
+
+  describe "default key (PUBLIC_KEY)" do
+    it "verifies a signature computed with PUBLIC_KEY when secret kwarg is omitted" do
+      sig = Base64.strict_encode64(
+        OpenSSL::HMAC.digest("SHA256", AbacatePay::Webhooks::PUBLIC_KEY, payload)
+      )
+      expect(described_class.verify!(payload: payload, signature: sig)).to be true
     end
   end
 


### PR DESCRIPTION
Small fixes uncovered while building a `pay-rails/pay` adapter on top of the SDK and exercising it against the AbacatePay sandbox **and production**. All low-risk, no public API changes — defaults align the SDK with what the API and the docs actually require today.

## 1. Compact `nil` keys before sending JSON payloads

The current API rejects requests like `{ "cellphone": null }` or `{ "description": null }` with HTTP 400:

> Expected property 'cellphone' to be string but found: null

The clients build payloads with optional fields and pass `nil` straight through. Adding `.compact` on the request hash matches what the API actually accepts. Affected:

- `clients/customer_client.rb#create`
- `clients/product_client.rb#create`

This was hit in production-style flows where a `Pay::Customer` had no `phone_number` set, and where one-time products were created without a `description`.

## 2. HMAC webhook signature: hex → base64

[`docs.abacatepay.com/pages/webhooks/security`](https://docs.abacatepay.com/pages/webhooks/security) specifies HMAC-SHA256 **base64-encoded** in the `X-Webhook-Signature` header. The previous implementation used `OpenSSL::HMAC.hexdigest`, which never matched the signatures the AbacatePay platform actually sends, so `verify!` rejected every real delivery as invalid.

## 3. Default the HMAC key to AbacatePay's documented `PUBLIC_KEY`

The same security doc states webhooks are signed with a fixed public key (not the per-webhook secret you configure in the dashboard — that one goes in the `?webhookSecret=` query parameter). The constant is exposed as `AbacatePay::Webhooks::PUBLIC_KEY` and is now the default for `verify!` / `valid?`, so callers that just want to verify a delivery don't have to know about it. The `secret:` kwarg still works for tests and for any future per-webhook signing scheme.

## 4. Recognize `abc_prod_` production keys (and stop masking API errors)

`Configuration#api_url` selects the API version (v1/v2) from the token prefix. It matched `abc_dev_` and `abc_live_` → v2, but **production keys are issued with the `abc_prod_` prefix**, which fell through to v1. Since the product endpoints (`POST /v2/products/create`, etc.) only exist on v2, every production call to them came back as:

> API error: Not found

…while the exact same code worked in sandbox (`abc_dev_` → v2). Widened the matcher to `/\Aabc_(dev|live|prod)_/` so production keys resolve to v2 too.

While here, `Client#request` wrapped **every** `StandardError` — including the `ApiError` it raises itself for `{"error": ...}` responses — into `ApiError, "Unexpected error: #{e.message}"`, double-wrapping the message and dropping the original context. `AbacatePay::Error` (and subclasses) now propagate untouched; only genuinely unexpected errors get the `Unexpected error` wrapper. This is what made the `Not found` above surface as the less useful `Unexpected error: API error: Not found`.

## Other

Adds `base64` as an explicit runtime dependency. Ruby 3.4 stopped shipping it as a default gem, so `require "base64"` started warning (and would eventually break).

## Test plan

- [x] `bundle exec rspec` — 333 examples, 0 failures
- [x] New `spec/configuration_spec.rb` covering version detection for `abc_dev_` / `abc_live_` / `abc_prod_` (→ v2) and legacy/nil tokens (→ v1); client spec asserts API error messages are no longer double-wrapped
- [x] Tested end-to-end against the AbacatePay sandbox: customer create, product create, hosted checkout, webhook receipt with both query-parameter auth and HMAC header
- [x] Reproduced the `abc_prod_` → v1 `Not found` against AbacatePay production, and confirmed the fix routes production keys to v2

🤖 Generated with [Claude Code](https://claude.com/claude-code)
